### PR TITLE
Added unit tests for "df_chat" app

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -1,0 +1,17 @@
+name: code_checks
+on: [pull_request]
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - run: python -m venv venv
+      - run: pip install -r requirements.txt
+      - run: source venv/bin/activate
+      - run: python manage.py migrate
+      - run: python manage.py test

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 .idea
 .DS_Store
 
+# visual studio code
+.vscode/*

--- a/df_chat/tests/test_chat.py
+++ b/df_chat/tests/test_chat.py
@@ -1,0 +1,132 @@
+from channels.db import database_sync_to_async
+# The WebsocketCommunicator provides convenient methods to simplify the process of connecting to a websocket.
+from channels.testing import WebsocketCommunicator
+from df_chat.models import Message, RoomUser
+from df_chat.tests.utils import TEST_USER_PASSWORD, RoomFactory, UserFactory
+from django.test import TransactionTestCase
+from rest_framework.reverse import reverse
+
+from tests.asgi import application
+
+
+class TestChat(TransactionTestCase):
+    """
+    Test for chat appplication
+    """
+
+    def setUp(self):
+        # Let's setup a room with two users in it.
+        self.room = RoomFactory()
+        self.user1 = UserFactory()
+        self.user2 = UserFactory()
+        self.room.users.set([self.user1, self.user2])
+
+        # Each user has to use an authentication token in order to connect with the websocket endpoint.
+        # So, lets generate and store them in attributes.
+        auth_token_url = reverse("token-list")
+        response = self.client.post(
+            auth_token_url,
+            data={"username": self.user1.username, "password": TEST_USER_PASSWORD},
+        )
+        self.token1 = response.json()["token"]
+        response = self.client.post(
+            auth_token_url,
+            data={"username": self.user2.username, "password": TEST_USER_PASSWORD},
+        )
+        self.token2 = response.json()["token"]
+
+    async def test_invalid_websocket_path(self):
+        """
+        We should reject the connection, if an invalid route is provided.
+        """
+        communicator = WebsocketCommunicator(application, "ws/dummy")
+        with self.assertRaisesMessage(ValueError, "No route found for path 'ws/dummy'"):
+            await communicator.connect()
+
+    async def test_auth(self):
+        """
+        Ensures that the authenticated user is added to the scope of the websocket consumer.
+        """
+        communicator = WebsocketCommunicator(
+            application, f"ws/chat/{self.room.id}/?token={self.token1}"
+        )
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+        # self.token1 belongs to self.user1
+        # Checking that our self.user1 was added to the scope.
+        self.assertEqual(communicator.scope["user"], self.user1)
+        await communicator.disconnect()
+
+    async def test_end_to_end(self):
+        """
+        An end-to-end test case to test the happy-path-flow of a chat between two users
+        """
+        # connecting our first user to the chat websocket endpoint
+        communicator1 = WebsocketCommunicator(
+            application, f"ws/chat/{self.room.id}/?token={self.token1}"
+        )
+        await communicator1.connect()
+
+        # As of now, there are no messages in the room
+        # The WebsocketCommunicator.receive_nothing returns a True, if there is no message to receive.
+        self.assertTrue(await communicator1.receive_nothing())
+        room_user1 = await database_sync_to_async(RoomUser.objects.get)(
+            room=self.room, user=self.user1
+        )
+
+        # connecting our second user to the chat websocket endpoint
+        communicator2 = WebsocketCommunicator(
+            application, f"ws/chat/{self.room.id}/?token={self.token2}"
+        )
+        await communicator2.connect()
+        room_user2 = await database_sync_to_async(RoomUser.objects.get)(
+            room=self.room, user=self.user2
+        )
+
+        # When another user connects to a room, the first user will receive a json dict stating that a user
+        # has connected to the room
+        event = await communicator1.receive_json_from()
+        self.assertEqual(
+            event["users"][0],
+            {
+                "id": room_user2.id,
+                "is_me": False,
+                "is_online": True,
+                "is_active": True,
+                "room_id": self.room.id,
+            },
+        )
+        # But, no messages are sent by the second user.
+        self.assertEqual(len(event["messages"]), 0)
+
+        # If a Message object is created, it should be received by both users
+        await database_sync_to_async(Message.objects.create)(
+            room_user=room_user1, body="Hi"
+        )
+        event1 = await communicator1.receive_json_from()
+        event2 = await communicator2.receive_json_from()
+        # Only one message will be received by each user
+        self.assertEqual(len(event1["messages"]), 1)
+        self.assertEqual(len(event2["messages"]), 1)
+        message_received_by_user1 = event1["messages"][0]
+        message_received_by_user2 = event2["messages"][0]
+        self.assertEqual(message_received_by_user1["body"], "Hi")
+        self.assertEqual(message_received_by_user1["room_id"], self.room.id)
+        self.assertEqual(message_received_by_user1["room_user_id"], room_user1.id)
+        self.assertEqual(message_received_by_user1["is_me"], True)
+        self.assertEqual(message_received_by_user2["is_me"], False)
+        # Except for "is_me", everything else in the message is same for both the users
+        del message_received_by_user1["is_me"]
+        del message_received_by_user2["is_me"]
+        self.assertDictEqual(message_received_by_user1, message_received_by_user2)
+
+
+# TODO: Trying to connect without providing a token results in an error "ValueError: 'AnonymousUser' value must be a positive integer or a valid Hashids string."
+# We should return a permission denied message via the websocket and gracefully disconnect the user.
+# TODO: In the current approach, in order to create a message in a room, a user should make a HTTP POST request.
+# And then the message is propagated to all the listeners in that room.
+# But, chatting is done in real-time. Users expect to send and receive messages real quick.
+# An HTTP connection not stateful. It takes time to connect. And disconnects immediately once the request is fulfiled.
+# On the other hand, a websocket connection is stateful - the connection is live until either party terminates it.
+# So, using websockets we could communicate in real time.
+# - we should allow users to create messages via websocket instead of HTTP.

--- a/df_chat/tests/utils.py
+++ b/df_chat/tests/utils.py
@@ -1,0 +1,33 @@
+import factory
+from df_chat.models import Room
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+TEST_USER_PASSWORD = "secret"
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    """
+    Factory for django's auth User model
+    """
+
+    class Meta:
+        model = User
+
+    username = factory.Faker("email")
+    password = factory.PostGenerationMethodCall("set_password", TEST_USER_PASSWORD)
+
+    is_active = True
+
+
+class RoomFactory(factory.django.DjangoModelFactory):
+    """
+    Factory for chat.models.Room
+    """
+
+    class Meta:
+        model = Room
+
+    title = factory.Faker("name")
+    creator = factory.SubFactory(UserFactory)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,6 @@ fcm-django<=1.0.12
 
 django-df-auth
 
+factory-boy
 pytest
 pytest-django


### PR DESCRIPTION
Having unit tests is a must for any application.
The https://github.com/djangoflow/django-df-chat/issues/2 talks about a refactoring, which could break the current flow of the chat app. So, with this test case we will be confident that the chat works the same as before(probably with some minute changes).

So, I have added the "df_chat.tests.TestChat" test case, to test the complete flow of our chat application - connection establishment, authentication and messaging.