### PR TITLE
Fix JWT token authentication for RESTful API endpoints

### DIFF
--- a/df_chat/tests/base.py
+++ b/df_chat/tests/base.py
@@ -1,0 +1,46 @@
+from channels.db import database_sync_to_async
+from df_chat.models import Room
+from df_chat.models import User
+from df_chat.tests.utils import RoomFactory
+from df_chat.tests.utils import TEST_USER_PASSWORD
+from df_chat.tests.utils import UserFactory
+from rest_framework.reverse import reverse
+from typing import Tuple
+
+
+class BaseTestUtilsMixin:
+    def create_user(self) -> Tuple[User, str]:
+        """
+        Creates a User object and generates an auth token for the user.
+        """
+        user = UserFactory()
+        # User has to use an authentication token in order to connect with the websocket endpoint.
+        auth_token_url = reverse("token-list")
+        response = self.client.post(
+            auth_token_url,
+            data={"username": user.username, "password": TEST_USER_PASSWORD},
+        )
+        token = response.json()["token"]
+        return user, token
+
+    def create_room_and_add_users(self, *users) -> Room:
+        """
+        Creates a Room object and adds the users to it.
+        """
+        room = RoomFactory()
+        room.users.set(users)
+        return room
+
+    @database_sync_to_async
+    def async_create_user(self) -> Tuple[User, str]:
+        """
+        Creates a User object and generates an auth token for the user.
+        """
+        return self.create_user()
+
+    @database_sync_to_async
+    def async_create_room_and_add_users(self, *users) -> Room:
+        """
+        Creates a Room object and adds the users to it.
+        """
+        return self.create_room_and_add_users(*users)

--- a/df_chat/tests/test_chat.py
+++ b/df_chat/tests/test_chat.py
@@ -2,44 +2,15 @@ from channels.db import database_sync_to_async
 from channels.testing import WebsocketCommunicator
 from df_chat.models import Message
 from df_chat.models import RoomUser
-from df_chat.models import User
-from df_chat.tests.utils import RoomFactory
-from df_chat.tests.utils import TEST_USER_PASSWORD
-from df_chat.tests.utils import UserFactory
+from df_chat.tests.base import BaseTestUtilsMixin
 from django.test import TransactionTestCase
-from rest_framework.reverse import reverse
 from tests.asgi import application
-from typing import Tuple
 
 
-class TestChat(TransactionTestCase):
+class TestChat(TransactionTestCase, BaseTestUtilsMixin):
     """
     Test for chat appplication
     """
-
-    @database_sync_to_async
-    def create_user(self) -> Tuple[User, str]:
-        """
-        Creates a User object and generates an auth token for the user.
-        """
-        user = UserFactory()
-        # User has to use an authentication token in order to connect with the websocket endpoint.
-        auth_token_url = reverse("token-list")
-        response = self.client.post(
-            auth_token_url,
-            data={"username": user.username, "password": TEST_USER_PASSWORD},
-        )
-        token = response.json()["token"]
-        return user, token
-
-    @database_sync_to_async
-    def create_room_and_add_users(self, *users):
-        """
-        Creates a Room object and adds the users to it.
-        """
-        room = RoomFactory()
-        room.users.set(users)
-        return room
 
     async def test_invalid_websocket_path(self):
         """
@@ -53,7 +24,7 @@ class TestChat(TransactionTestCase):
         """
         Ensures that the authenticated user is added to the scope of the websocket consumer.
         """
-        user, token = await self.create_user()
+        user, token = await self.async_create_user()
         communicator = WebsocketCommunicator(application, f"ws/chat/?token={token}")
         connected, _ = await communicator.connect()
         self.assertTrue(connected)
@@ -66,9 +37,9 @@ class TestChat(TransactionTestCase):
         An end-to-end test case to test the happy-path-flow of a chat between two users in a single room.
         """
         # creating a room with two users
-        user1, token1 = await self.create_user()
-        user2, token2 = await self.create_user()
-        room = await self.create_room_and_add_users(user2, user1)
+        user1, token1 = await self.async_create_user()
+        user2, token2 = await self.async_create_user()
+        room = await self.async_create_room_and_add_users(user2, user1)
 
         # connecting our first user to the chat websocket endpoint
         communicator1 = WebsocketCommunicator(application, f"ws/chat/?token={token1}")
@@ -136,12 +107,16 @@ class TestChat(TransactionTestCase):
         An end-to-end test case to test the happy-path-flow of a chat for a user connected to multiple rooms.
         """
         # creating three users
-        user1, token1 = await self.create_user()
-        user2, token2 = await self.create_user()
-        user3, token3 = await self.create_user()
+        user1, token1 = await self.async_create_user()
+        user2, token2 = await self.async_create_user()
+        user3, token3 = await self.async_create_user()
         # creating two rooms, where user1 is present in both.
-        room_of_user1_and_user2 = await self.create_room_and_add_users(user1, user2)
-        room_of_user1_and_user3 = await self.create_room_and_add_users(user1, user3)
+        room_of_user1_and_user2 = await self.async_create_room_and_add_users(
+            user1, user2
+        )
+        room_of_user1_and_user3 = await self.async_create_room_and_add_users(
+            user1, user3
+        )
 
         # connecting the first, second and third users to the chat websocket endpoint, simultaneously
         communicator1 = WebsocketCommunicator(application, f"ws/chat/?token={token1}")

--- a/df_chat/tests/test_message_endpoint.py
+++ b/df_chat/tests/test_message_endpoint.py
@@ -1,0 +1,34 @@
+from df_chat.tests.base import BaseTestUtilsMixin
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+
+class TestMessageEndpoint(APITestCase, BaseTestUtilsMixin):
+    """
+    Testing the RESTful API messages endpoint
+    """
+
+    def test_message_creation_success(self):
+        """
+        Testing creation of a message using the messages endpoint.
+        """
+        user, token = self.create_user()
+        room = self.create_room_and_add_users(user)
+
+        message_endpoint = reverse("rooms-messages-list", kwargs={"room_pk": room.pk})
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + token)
+        response = self.client.post(message_endpoint, {"body": "Hi"})
+        message = response.json()
+
+        room_user = user.roomuser_set.get()
+        self.assertEqual(message["body"], "Hi")
+        self.assertTrue(message["is_me"])
+        self.assertEqual(message["room_user_id"], room_user.pk)
+        self.assertIsNone(message["parent_id"])
+        self.assertFalse(message["is_reaction"])
+
+    # TODOS: We should also implement the following tests:
+    # - Fail to create a message when the user is not authenticated.
+    # - Ensure that the endpoint returns a 404 error
+    #   - if the user is not part of a Room
+    #   - if a room doesn't exist at all.

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -113,3 +113,10 @@ DF_NOTIFICATIONS = {
 DF_AUTH = {
     "USER_IDENTITY_FIELDS": ("username",),
 }
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ),
+    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
+}


### PR DESCRIPTION
## Issue
Regression introduced in commit https://github.com/djangoflow/django-df-chat/commit/6ca78e273ef4286a77fe9a525e479b93daf66ca5
- The REST_FRAMEWORK config was removed from the django settings.
- This caused the JWT token authentication to fail.

Due to this the `/api/v1/chat/<room_pk>/messages/` endpoint is returning a 403 Forbidden error response.

## Fix
- Added the REST_FRAMEWORK config to django settings.
- Created a "BaseTestUtilsMixin", which holds the following methods:
  - `create_user` and `create_room_and_add_users`, to be used by synchronous test methods.
  - `async_create_user` and `async_create_room_and_add_users`, to be used by asynchronous test methods. Mostly used in the testing of websocket communication.
- Added unit test to test creation of message using the messages endpoint.