### PR TITLE
Added django-extensions to generate model graph

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,6 @@ factory-boy
 pytest
 pytest-django
 pre-commit
+django-extensions
+pyparsing
+pydot

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -30,7 +30,12 @@ INSTALLED_APPS = [
     "django_celery_beat",
     "otp_twilio",
     "df_chat",
+    "django_extensions"
 ]
+
+GRAPH_MODELS = {
+  'group_models': True,
+}
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION
I completely understand if you prefer not to add deps but as I added it anyways to generate model graphs in the README, here's my suggestion.