### PR TITLE
Test and fix WebSocket closing on auth failure.

### DIFF
--- a/df_chat/asgi/consumers.py
+++ b/df_chat/asgi/consumers.py
@@ -100,6 +100,11 @@ class RoomsConsumer(GenericAsyncAPIConsumer):
         """
         Unsubscribe from all rooms
         """
+        # Unauthenticated users are not subscribed.
+        # (This is called on channel close.)
+        if not self.user.is_authenticated:
+            return
+
         rooms = await self.get_rooms()
         for room in rooms:
             await self.room_user_activity.unsubscribe(room_pk=room.pk)

--- a/df_chat/tests/test_chat.py
+++ b/df_chat/tests/test_chat.py
@@ -6,11 +6,11 @@ from df_chat.tests.utils import RoomFactory
 from df_chat.tests.utils import TEST_USER_PASSWORD
 from df_chat.tests.utils import UserFactory
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
 from django.test import TransactionTestCase
 from rest_framework.reverse import reverse
 from tests.asgi import application
 from typing import Tuple
-
 
 User = get_user_model()
 
@@ -62,6 +62,20 @@ class TestChat(TransactionTestCase):
         self.assertTrue(connected)
         # Checking that our user was added to the scope.
         self.assertEqual(communicator.scope["user"], user)
+        await communicator.disconnect()
+
+    async def test_auth_fail(self):
+        """
+        Trying to connect without providing a token should result in permission denied.
+
+        Regression for: https://github.com/djangoflow/django-df-chat/issues/13
+        """
+        user, token = await self.create_user()
+        communicator = WebsocketCommunicator(application, f"ws/chat/")
+        connected, _ = await communicator.connect()
+        self.assertFalse(connected)
+        # Checking that our user was added to the scope.
+        self.assertIsInstance(communicator.scope["user"], AnonymousUser)
         await communicator.disconnect()
 
     async def test_chat_single_room(self):


### PR DESCRIPTION
While trying to replicate #13, I found the following error instead:

```
    @database_sync_to_async
    def get_rooms(self):
        # Unauthenticated users should not hit our DB at all.
        # if not self.user.is_authenticated:
        #     return []
    
>       rooms = self.user.room_set.all()
E       AttributeError: 'AnonymousUser' object has no attribute 'room_set'
```

We should not hit the DB for unauthenticated users. This was due to `unsubscribe_from_all_activities` being called on `close()`. I provide a regression test and a patch where unauthenticated users are assumed not to have open WebSockets which resolves this issue.